### PR TITLE
Change exponential backoff test

### DIFF
--- a/src/test/scala/pt/tecnico/dsi/BackoffSpec.scala
+++ b/src/test/scala/pt/tecnico/dsi/BackoffSpec.scala
@@ -1,14 +1,17 @@
 package pt.tecnico.dsi
 
+import org.scalacheck.Gen
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.{TableDrivenPropertyChecks, GeneratorDrivenPropertyChecks}
 
 import scala.concurrent.duration._
 
 abstract class UnitSpec extends FlatSpec with Matchers
 with OptionValues with Inside with Inspectors
 
-class BackoffSpec extends PropSpec with GeneratorDrivenPropertyChecks with ShouldMatchers {
+class BackoffSpec extends PropSpec with
+  GeneratorDrivenPropertyChecks with
+  ShouldMatchers {
 
   property("Using the constant function should always return the same value") {
     forAll { iteration: Int =>
@@ -28,14 +31,15 @@ class BackoffSpec extends PropSpec with GeneratorDrivenPropertyChecks with Shoul
     }
   }
 
+  val duration = 1.seconds
+  val maxIteration = math.floor(math.log(Long.MaxValue / duration.toNanos) / math.log(2)).toInt
+  val generator = for(n <- Gen.choose(0,maxIteration-1)) yield n
   property("Using the exponential function should return a constant ratio between two iterations") {
-    forAll { iteration: Int =>
-      val duration = 1.seconds
-      val maxIteration = math.floor(math.log(Long.MaxValue / duration.toNanos) / math.log(2)).toInt
-
-      whenever(iteration >= 0 && iteration < maxIteration) {
-        Backoff.exponential(iteration, duration) * 2 shouldBe Backoff.exponential(iteration + 1, duration)
-      }
+    forAll(generator) { iteration =>
+      val x = Backoff.exponential(iteration, duration) * 2
+      val y = Backoff.exponential(iteration + 1, duration)
+      println(s"it:$iteration x:$x y:$y max:$maxIteration")
+      x shouldBe y
     }
   }
 

--- a/src/test/scala/pt/tecnico/dsi/BackoffSpec.scala
+++ b/src/test/scala/pt/tecnico/dsi/BackoffSpec.scala
@@ -2,20 +2,19 @@ package pt.tecnico.dsi
 
 import org.scalacheck.Gen
 import org.scalatest._
-import org.scalatest.prop.{TableDrivenPropertyChecks, GeneratorDrivenPropertyChecks}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 import scala.concurrent.duration._
 
-abstract class UnitSpec extends FlatSpec with Matchers
-with OptionValues with Inside with Inspectors
+abstract class UnitSpec extends FlatSpec with Matchers with OptionValues with Inside with Inspectors
 
-class BackoffSpec extends PropSpec with
-  GeneratorDrivenPropertyChecks with
-  ShouldMatchers {
+class BackoffSpec extends PropSpec with GeneratorDrivenPropertyChecks with  ShouldMatchers {
+  private val duration = 1.seconds
+  private val maxIteration = math.floor(math.log(Long.MaxValue / duration.toNanos) / math.log(2)).toInt
+  private val generator = for (n <- Gen.choose(0, maxIteration - 1)) yield n
 
   property("Using the constant function should always return the same value") {
     forAll { iteration: Int =>
-      val duration = 1.seconds
       whenever(iteration >= 0 && iteration < Int.MaxValue) {
         Backoff.constant(iteration, duration) shouldBe duration
       }
@@ -24,28 +23,22 @@ class BackoffSpec extends PropSpec with
 
   property("Using the linear function should return a constant difference between two iterations") {
     forAll { iteration: Int =>
-      val duration = 1.seconds
       whenever(iteration >= 0 && iteration < Int.MaxValue) {
         Backoff.linear(iteration, duration) + duration shouldBe Backoff.linear(iteration + 1, duration)
       }
     }
   }
 
-  val duration = 1.seconds
-  val maxIteration = math.floor(math.log(Long.MaxValue / duration.toNanos) / math.log(2)).toInt
-  val generator = for(n <- Gen.choose(0,maxIteration-1)) yield n
+
   property("Using the exponential function should return a constant ratio between two iterations") {
     forAll(generator) { iteration =>
-      val x = Backoff.exponential(iteration, duration) * 2
-      val y = Backoff.exponential(iteration + 1, duration)
-      println(s"it:$iteration x:$x y:$y max:$maxIteration")
-      x shouldBe y
+      Backoff.exponential(iteration, duration) * 2 shouldBe Backoff.exponential(iteration + 1, duration)
+
     }
   }
 
   property("Using the fibonacci function should return a constant ratio(golden ratio) between two iterations") {
     forAll { iteration: Int =>
-      val duration = 1.seconds
       whenever(iteration >= 0 && iteration < Int.MaxValue) {
         Backoff.fibonacci(iteration, duration) * Backoff.goldenRatio shouldBe Backoff.fibonacci(iteration + 1, duration)
       }


### PR DESCRIPTION
Changed the way the test was implemented to use a generator all possible values since for the duration of 1 second there are only 33 possible iterations.
